### PR TITLE
Varnish hostname should default to the hostname passed in

### DIFF
--- a/bin/varnisher
+++ b/bin/varnisher
@@ -22,14 +22,12 @@ Main {
   option('H', 'hostname') {
     argument :required
     description "The hostname/IP address of your Varnish server."
-    default "localhost"
   }
 
   option('p', 'port') {
     argument :required
     cast :int
     description "The port Varnish is listening on."
-    default 80
   }
 
   def before_run
@@ -69,24 +67,20 @@ Main {
       argument :required
       cast :int
       description "Maximum number of pages to crawl. Setting this to -1 (the default) will impose no limit."
-      default -1
     }
 
     option('t', 'threads') {
       argument :required
       cast :int
       description "Spidering is done in parallel; this variable controls how many threads will be used."
-      default 16
     }
 
     option('#', 'ignore-hashes') {
       description "When given, /foo#foo and /foo#bar will be treated as separate URLs; the default is to treat them as the same resource."
-      default true
     }
 
     option('q', 'ignore-query-strings') {
       description "When given, /foo?foo=bar and /foo?foo=baz will be treated as the same resource."
-      default false
     }
 
     def run

--- a/lib/varnisher.rb
+++ b/lib/varnisher.rb
@@ -11,13 +11,13 @@ module Varnisher
   # Our default options are set here; they can be overriden either by
   # command-line arguments or by settings in a user's ~/.varnishrc file.
   @options = {
-    verbose: false,
-    hostname: nil,
-    port: 80,
-    :'num-pages' => -1,
-    threads: 16,
-    :'ignore-hashes' => true,
-    :'ignore-query-strings' => false
+    'verbose' => false,
+    'hostname' => nil,
+    'port' => 80,
+    'num-pages' => -1,
+    'threads' => 16,
+    'ignore-hashes' => true,
+    'ignore-query-strings' => false
   }
 
   def self.options
@@ -26,6 +26,14 @@ module Varnisher
 
   def self.options=(options)
     @options = options
+
+    if options['hostname'].nil? and options['target']
+      begin
+        uri = URI.parse(options['target'])
+        options['hostname'] = uri.host
+      rescue
+      end
+    end
   end
 end
 


### PR DESCRIPTION
It's likely that this will work in 99% of cases — certainly a lot more than `localhost` will, which is the current default.
