### PR TITLE
Bug fixed, ignore #.

### DIFF
--- a/lib/varnisher/spider.rb
+++ b/lib/varnisher/spider.rb
@@ -108,9 +108,10 @@ module Varnisher
     def find_links(doc, uri)
       urls = Varnisher::Urls.new(get_anchors(doc) + get_commented_urls(doc))
 
+      urls = urls.without_hashes if Varnisher.options['ignore-hashes']
+
       urls = urls.make_absolute(uri).with_hostname(uri.host)
 
-      urls = urls.without_hashes if Varnisher.options['ignore-hashes']
       urls = urls.without_query_strings if Varnisher.options['ignore-query-strings']
 
       urls


### PR DESCRIPTION
URI.escape will change # to be %23, and it can't be removed by URI.fragment = nil.